### PR TITLE
fix copy-paste error in server template

### DIFF
--- a/tools/server-template.yaml
+++ b/tools/server-template.yaml
@@ -1,8 +1,8 @@
 kind: Template
 apiVersion: v1
-template: spark
+template: oshinko-rest
 metadata:
-  name: spark
+  name: oshinko-rest
 objects:
 
 - kind: Service


### PR DESCRIPTION
The old values for the template metadata name and the template values we
leftover from the source template. These have been changed to something
oshinko specific.
