### PR TITLE
Add helper packages for creating clients and retrieving info

### DIFF
--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -5,7 +5,7 @@ import (
 )
 
 func makeSingleErrorResponse(status int32, title string, details string) *models.ErrorResponse {
-	error := models.ErrorModel {Status: &status, Details: &details,	Title: &title}
-	response := models.ErrorResponse {Errors: []*models.ErrorModel {&error}}
+	error := models.ErrorModel{Status: &status, Details: &details, Title: &title}
+	response := models.ErrorResponse{Errors: []*models.ErrorModel{&error}}
 	return &response
 }

--- a/helpers/authentication/authentication.go
+++ b/helpers/authentication/authentication.go
@@ -1,0 +1,40 @@
+package authentication
+
+import (
+	"errors"
+	_ "github.com/openshift/origin/pkg/api/install"
+	"github.com/openshift/origin/pkg/client"
+	serverapi "github.com/openshift/origin/pkg/cmd/server/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"os"
+)
+
+func GetKubeClient() (*kclient.Client, error) {
+
+	// If the configfile option has been
+	// set, use it to get a client otherwise use the
+	// serviceaccount for authentication
+	configfile := os.Getenv("OSHINKO_KUBE_CONFIG")
+	if configfile != "" {
+		client, _, err := serverapi.GetKubeClient(configfile)
+		return client, err
+	} else {
+		// TODO whatever we have to do here to get a client using the serviceaccount
+		return nil, errors.New("OSHINKO_KUBE_CONFIG env var is required at this time")
+	}
+}
+
+func GetOpenShiftClient() (*client.Client, error) {
+
+	// If the configfile option has been
+	// set, use it to get a client otherwise use the
+	// serviceaccount for authentication
+	configfile := os.Getenv("OSHINKO_KUBE_CONFIG")
+	if configfile != "" {
+		client, _, err := serverapi.GetOpenShiftClient(configfile)
+		return client, err
+	} else {
+		// TODO whatever we have to do here to get a client using the serviceaccount
+		return nil, errors.New("OSHINKO_KUBE_CONFIG env var is required at this time")
+	}
+}

--- a/helpers/info/info.go
+++ b/helpers/info/info.go
@@ -1,0 +1,15 @@
+package info
+
+import (
+	"os"
+)
+
+func GetNamespace() (string, error) {
+	// TODO if we're running in a pod is there a cool way to get the current namespace?
+	return os.Getenv("OSHINKO_CLUSTER_NAMESPACE"), nil
+}
+
+func GetSparkImage() (string, error) {
+	// TODO is there a good well-known location for a spark image?
+	return os.Getenv("OSHINKO_CLUSTER_IMAGE"), nil
+}


### PR DESCRIPTION
This commit adds helpers/authentication to encapsulate client
creation so that oshinko-rest can easily be run in a pod or from the
command line. It also adds helpers/info for retrieving things like
the spark image location.
