### PR TITLE
Add support for running oshinko-rest-server in a pod

### DIFF
--- a/helpers/authentication/authentication.go
+++ b/helpers/authentication/authentication.go
@@ -46,14 +46,7 @@ func SAConfig() (*restclient.Config, error) {
 
 func GetKubeClient() (*kclient.Client, error) {
 
-	// If the configfile option has been
-	// set, use it to get a client otherwise use the
-	// serviceaccount for authentication
-	configfile := info.GetKubeConfigPath()
-	if configfile != "" {
-		client, _, err := serverapi.GetKubeClient(configfile)
-		return client, err
-	} else {
+	if info.InAPod() {
 		saConfig, err := SAConfig()
 		if err != nil {
 			return nil, err
@@ -63,19 +56,15 @@ func GetKubeClient() (*kclient.Client, error) {
 			return nil, err
 		}
 		return client, err
+	} else {
+		client, _, err := serverapi.GetKubeClient(info.GetKubeConfigPath())
+		return client, err
 	}
 }
 
 func GetOpenShiftClient() (*client.Client, error) {
 
-	// If the configfile option has been
-	// set, use it to get a client otherwise use the
-	// serviceaccount for authentication
-	configfile := info.GetKubeConfigPath()
-	if configfile != "" {
-		client, _, err := serverapi.GetOpenShiftClient(configfile)
-		return client, err
-	} else {
+	if info.InAPod() {
 		saConfig, err := SAConfig()
 		if err != nil {
 			return nil, err
@@ -84,6 +73,9 @@ func GetOpenShiftClient() (*client.Client, error) {
 		if err != nil {
 			return nil, err
 		}
+		return client, err
+	} else {
+		client, _, err := serverapi.GetOpenShiftClient(info.GetKubeConfigPath())
 		return client, err
 	}
 }

--- a/helpers/info/info.go
+++ b/helpers/info/info.go
@@ -10,8 +10,19 @@ const CA_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 const TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 const NS_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
+func InAPod() bool {
+	return os.Getenv("OSHINKO_REST_POD_NAME") != ""
+}
+
 func GetNamespace() (string, error) {
-	//If running in a pod use GetServiceAccountNS()
+	if InAPod() {
+		// Try the secrets file first
+		// If that fails, fall back to env var
+		ns, err := GetServiceAccountNS()
+		if ns != nil && err == nil {
+			return string(ns), err
+		}
+	}
 	return os.Getenv("OSHINKO_CLUSTER_NAMESPACE"), nil
 }
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,13 +6,42 @@ This is a template that can be processed for adding an oshinko-rest-server
 image to OpenShift. It maintains the default 0.0.0.0:8080 host:port option
 for the server.
 
-To use this template, an oshinko-rest-server image must first be tagged into
-the OpenShift project. Then the template must be processed with the location
-for the image. Finally, the output of the processed template can be used
-to create the service and pod.
+To use this template, an oshinko-rest-server image and a spark image must
+first be tagged into the OpenShift project. Then the template must be
+processed with the locations of the images. Finally, the output of the
+processed template can be used to create the service and pod.
+
+## Service account
+
+The oshinko-rest-server uses an "oshinko" service account to perform openshift
+operations. This service account must be created and given the admin role in
+*each* project which will use the oshinko-rest-server, for example:
+
+Create a new project *myproject*:
+
+    $ oc new-project myproject
+
+Create the oshinko service account:
+
+    $ more sa.json
+    {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "name": "oshinko"
+      }
+    }
+
+    $ oc create -f sa.json
+
+Assign the admin role:
+
+    $ oc policy add-role-to-user admin system:serviceaccount:myproject:oshinko -n myproject
+
+## Sample template usage
 
 Example usage with an internal registry at 172.30.159.57:5000, and a project
 named "myproject":
 
-    $ oc process -f server-template.yaml -v OSHINKO_SERVER_IMAGE=172.30.159.57:5000/myproject/oshinko-rest-server > server-template.json
+    $ oc process -f server-template.yaml -v OSHINKO_SERVER_IMAGE=172.30.159.57:5000/myproject/oshinko-rest-server, OSHINKO_CLUSTER_IMAGE=172.30.159.57:5000/myproject/openshift-spark > server-template.json
     $ oc create -f server-template.json

--- a/tools/server-template.yaml
+++ b/tools/server-template.yaml
@@ -16,7 +16,7 @@ objects:
       - name: oshinko-rest-port
         protocol: TCP
         port: 8080
-        targetPort: rest-port
+        targetPort: 8080
     selector:
       name: ${SERVER_NAME}
 
@@ -43,11 +43,21 @@ objects:
             env:
               - name: OSHINKO_SERVER_PORT
                 value: "8080"
+              - name: OSHINKO_REST_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: OSHINKO_CLUSTER_NAMESPACE
+                valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              - name: OSHINKO_CLUSTER_IMAGE
+                value: ${OSHINKO_CLUSTER_IMAGE}
             ports:
               - name: rest-port
                 containerPort: 8080
                 protocol: TCP
-
+        serviceaccount: oshinko
 parameters:
 - name: OSHINKO_SERVER_IMAGE
   description: Full name of the oshinko server image
@@ -56,4 +66,6 @@ parameters:
   description: Name of the oshinko server service
   generate: expression
   from: "oshinko-rest-[a-z0-9]{4}"
+  required: true
+- name: OSHINKO_CLUSTER_IMAGE
   required: true


### PR DESCRIPTION
Fixed up the code and modified the tools/servier-template.yaml. For the moment, left the spark image as a parameter to be set.
