### PR TITLE
fix cluster tests

### DIFF
--- a/tests/clusters_client_test.go
+++ b/tests/clusters_client_test.go
@@ -16,7 +16,7 @@ func (s *OshinkoRestTestSuite) TestCreateCluster(c *check.C) {
 
 	_, err := s.cli.Clusters.CreateCluster(params)
 
-	expectedStatusCode := 501
+	expectedStatusCode := 500
 	observedStatusCode := err.(*clusters.CreateClusterDefault).Code()
 
 	c.Assert(observedStatusCode, check.Equals, expectedStatusCode)
@@ -27,7 +27,7 @@ func (s *OshinkoRestTestSuite) TestDeleteSingleCluster(c *check.C) {
 
 	_, err := s.cli.Clusters.DeleteSingleCluster(params)
 
-	expectedStatusCode := 501
+	expectedStatusCode := 500
 	observedStatusCode := err.(*clusters.DeleteSingleClusterDefault).Code()
 
 	c.Assert(observedStatusCode, check.Equals, expectedStatusCode)
@@ -36,7 +36,7 @@ func (s *OshinkoRestTestSuite) TestDeleteSingleCluster(c *check.C) {
 func (s *OshinkoRestTestSuite) TestFindClusters(c *check.C) {
 	_, err := s.cli.Clusters.FindClusters(nil)
 
-	expectedStatusCode := 501
+	expectedStatusCode := 500
 	observedStatusCode := err.(*clusters.FindClustersDefault).Code()
 
 	c.Assert(observedStatusCode, check.Equals, expectedStatusCode)
@@ -47,7 +47,7 @@ func (s *OshinkoRestTestSuite) TestFindSingleCluster(c *check.C) {
 
 	_, err := s.cli.Clusters.FindSingleCluster(params)
 
-	expectedStatusCode := 501
+	expectedStatusCode := 500
 	observedStatusCode := err.(*clusters.FindSingleClusterDefault).Code()
 
 	c.Assert(observedStatusCode, check.Equals, expectedStatusCode)
@@ -62,7 +62,7 @@ func (s *OshinkoRestTestSuite) TestUpdateSingleCluster(c *check.C) {
 
 	_, err := s.cli.Clusters.UpdateSingleCluster(params)
 
-	expectedStatusCode := 501
+	expectedStatusCode := 500
 	observedStatusCode := err.(*clusters.UpdateSingleClusterDefault).Code()
 
 	c.Assert(observedStatusCode, check.Equals, expectedStatusCode)


### PR DESCRIPTION
The cluster tests rely on a working openshift client to make the calls.
Previously, these had all returned 501 from the http framework but now
we are returning the proper 500 when no kubernetes configuration is
found. The tests have been adjusted to receive the 500 that is now
returned.
