### PR TITLE
add a default logger to the api structure

### DIFF
--- a/restapi/configure_oshinko_rest.go
+++ b/restapi/configure_oshinko_rest.go
@@ -59,6 +59,8 @@ func configureAPI(api *operations.OshinkoRestAPI) http.Handler {
 		}
 	}
 
+	api.Logger = logging.GetLogger().Printf
+
 	return setupGlobalMiddleware(api.Serve(setupMiddlewares))
 }
 


### PR DESCRIPTION
In a more recent release of go-swagger, they have added a function
handle to the api structure for customizing the logging behavior. This
patch connects our logging mechanism with the default server logger.
