### PR TITLE
Add a simple bash script to setup an oshinko dev env

### DIFF
--- a/tools/oshinko-setup.sh
+++ b/tools/oshinko-setup.sh
@@ -67,9 +67,6 @@ sudo oc cluster up
 # Get the address of the docker registry so we can push our images to it
 sudo oc login -u system:admin
 sudo oc project default
-#REGISTRY=$(sudo oc get service docker-registry --no-headers=true | awk -F ' ' '{print $2":"$4}' | sed "s,/TCP$,,")
-#ROUTERIP=$(sudo oc get service router --no-headers=true | awk -F ' ' '{print $2}')
-
 REGISTRY=$(sudo oc get service docker-registry --template='{{index .spec.clusterIP}}:{{index .spec.ports 0 "port"}}')
 ROUTERIP=$(sudo oc get service router --template='{{index .spec.clusterIP}}')
 


### PR DESCRIPTION
This is a bit rough and can certainly use improvement,
but it's a baseline for getting oshinko up and running
on a fresh VM. Tested this on F23.

Note, it's relatively idempotent. Running this multiple
times from the same root directory showed no problems
(except that your local image registry will fill up
with tags :) )
- Clone the oshinko repos
- build all the images
- install an openshift cluster with oc cluster up
- create an "oshinko" user and project
- tag and push all the images
- launch the standard server-ui-template.yaml
