### PR TITLE
Fix problems with find cluster

### DIFF
--- a/handlers/clusters.go
+++ b/handlers/clusters.go
@@ -536,9 +536,13 @@ func FindClustersResponse(params clusters.FindClustersParams) middleware.Respond
 
 			// TODO we only want to count running pods (not terminating)
 			citem.WorkerCount = toint64ptr(cnt)
-			// TODO make something real for status
-			citem.Status = tostrptr("Running")
 			citem.MasterURL = tostrptr(retrieveMasterURL(sc, clustername))
+			// TODO make something real for status
+			if *citem.MasterURL == "" {
+				citem.Status = tostrptr("MasterServiceMissing")
+			} else {
+				citem.Status = tostrptr("Running")
+			}
 			payload.Clusters = append(payload.Clusters, citem)
 		}
 	}


### PR DESCRIPTION
- look for deploymentconfigs as a determining factor for presence of cluster (issue #35)
- return 404 when a cluster is missing (issue #22)
- also set a MissingMasterService status on the cluster when it is present but the
  spark master service has been deleted.
