### PR TITLE
Add standard env vars for spark master and workers

### DIFF
--- a/helpers/containers/containers.go
+++ b/helpers/containers/containers.go
@@ -28,7 +28,7 @@ func (c *OContainer) EnvVar(name, value string) *OContainer {
 	return c
 }
 
-func (c *OContainer) EnvVars(envs ...kapi.EnvVar) *OContainer {
+func (c *OContainer) EnvVars(envs []kapi.EnvVar) *OContainer {
 	c.Container.Env = envs
 	return c
 }

--- a/tests/unit/containers_test.go
+++ b/tests/unit/containers_test.go
@@ -36,7 +36,7 @@ func (s *OshinkoUnitTestSuite) TestEnvVars(c *check.C) {
 	expectedEnv := []kapi.EnvVar{
 		kapi.EnvVar{Name: "name1", Value: "value1"},
 		kapi.EnvVar{Name: "name2", Value: "value2"}}
-	newContainer.EnvVars(expectedEnv[0], expectedEnv[1])
+	newContainer.EnvVars(expectedEnv)
 	c.Assert(newContainer.Container.Env, check.DeepEquals, expectedEnv)
 }
 

--- a/tools/server-ui-template.yaml
+++ b/tools/server-ui-template.yaml
@@ -161,17 +161,13 @@ parameters:
   required: true
 - name: OSHINKO_SERVER_NAME
   description: Name of the oshinko server service
-  generate: expression
-  from: "oshinko-rest-[a-z0-9]{4}"
-  required: true
+  value: "oshinko-rest"
 - name: OSHINKO_CLUSTER_IMAGE
   description: Full name of the spark image to use when creating clusters
   required: true
 - name: OSHINKO_WEB_NAME
   description: Name of the oshinko web service
-  generate: expression
-  from: "oshinko-web-[a-z0-9]{4}"
-  required: true
+  value: "oshinko-web"
 - name: OSHINKO_WEB_IMAGE
   description: Full name of the oshino web image
   required: true


### PR DESCRIPTION
Implementing the predefined-env-vars.md spec in oshinko-specs

This change adds the following env vars to the spark containers:
- OSHINKO_SPARK_CLUSTER
- OSHINKO_REST_HOST
- OSHINKO_REST_PORT

Additionally, the standard template has been changed to remove
the random element from the oshinko-rest and oshinko-web server
names.
