### PR TITLE
Fixing scaling operations for clusters that have been tweaked

### DIFF
--- a/handlers/clusters.go
+++ b/handlers/clusters.go
@@ -678,7 +678,13 @@ func UpdateSingleClusterResponse(params clusters.UpdateSingleClusterParams) midd
 	}
 	// Use the latest replication controller.  There could be more than one
 	// if the user did something like oc env to set a new env var on a deployment
-	repl := repls.Items[len(repls.Items) - 1]
+	newestRepl := repls.Items[0]
+	for i := 0; i < len(repls.Items); i++ {
+		if repls.Items[i].CreationTimestamp.Unix() > newestRepl.CreationTimestamp.Unix() {
+			newestRepl = repls.Items[i]
+		}
+	}
+	repl := newestRepl
 
 	// If the current replica count does not match the request, update the replication controller
 	if repl.Spec.Replicas != workercount {


### PR DESCRIPTION
In the event that a user tweaks a cluster in a way that results
in a new deployment for workers (using oc env to set or change
and env var is one example of such an action), we need to use
the newer replication controller, which should be at the end of
the array.  This addresses issue #49.
