### PR TITLE
correct description of Location header

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -228,7 +228,7 @@ paths:
           headers:
             Location:
               description: |-
-                URL of the cluster, this is oshinko specific
+                URL of the cluster detail page within the oshinko rest server
               type: string
           schema:
             $ref: "#/definitions/SingleCluster"


### PR DESCRIPTION
This change makes it more explicit that the Location header should be
used for the cluster detail page in the oshinko rest server.
