### PR TITLE
fix empty responses in error middleware

### DIFF
--- a/helpers/errors/middleware.go
+++ b/helpers/errors/middleware.go
@@ -100,6 +100,8 @@ func AddErrorHandler(next http.Handler) http.Handler {
 					NewSingleErrorResponse(int32(er.status), statusCode(er.status), mesg))
 			}
 		}
-		w.Write(*resp)
+		if resp != nil {
+			w.Write(*resp)
+		}
 	})
 }

--- a/tests/unit/errors_test.go
+++ b/tests/unit/errors_test.go
@@ -22,8 +22,9 @@ func (s *OshinkoUnitTestSuite) TestNewSingleErrorReponse(c *check.C) {
 }
 
 type testResponseWriter struct {
-	header   http.Header
-	response *[]byte
+	header      http.Header
+	response    *[]byte
+	writeCalled bool
 }
 
 func (w *testResponseWriter) Header() http.Header {
@@ -77,4 +78,12 @@ func (s *OshinkoUnitTestSuite) TestAddErrorHandler(c *check.C) {
 	wrappedHandler.ServeHTTP(&testWriter, &testRequest)
 	c.Assert(*testWriter.response, check.DeepEquals, expectedResponse)
 	c.Assert(observedWriteLen, check.Equals, expectedWriteLen)
+
+	testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	})
+	wrappedHandler = errors.AddErrorHandler(testHandler)
+	testWriter = testResponseWriter{}
+	wrappedHandler.ServeHTTP(&testWriter, &testRequest)
+	c.Assert(testWriter.writeCalled, check.Equals, false)
 }


### PR DESCRIPTION
The error middleware was attempting to dereference a nil pointer in
cases where the underlying handler object had no response to write. This
change will make sure that the middleware does not attempt to write
these empty responses. This also adds a unit test to exercise the
behavior.

Changes
- add nil detection to error middleware response
- add unit test for nil response

this closes issue #55 
