### PR TITLE
Fix the Location header on cluster create.

### DIFF
--- a/handlers/clusters.go
+++ b/handlers/clusters.go
@@ -390,7 +390,7 @@ func CreateClusterResponse(params clusters.CreateClusterParams) middleware.Respo
 	if err != nil {
 		return reterr(responseFailure(err, respMsg, 500))
 	}
-	return clusters.NewCreateClusterCreated().WithLocation(masterurl).WithPayload(cluster)
+	return clusters.NewCreateClusterCreated().WithLocation("/clusters/"+clustername).WithPayload(cluster)
 }
 
 func waitForCount(client kclient.ReplicationControllerInterface, name string, count int) {


### PR DESCRIPTION
The Location header currently contains the masterurl,
this is incorrect. It should be the url for the cluster
details page in the oshinko-rest server, "/clusters/mycluster"
for example.
