### PR TITLE
remove empty tests

### DIFF
--- a/tests/unit/authentication_test.go
+++ b/tests/unit/authentication_test.go
@@ -1,4 +1,0 @@
-// INFO (elmiko)
-// Adding this file as a placeholder for the helpers/authentication package,
-// this file will require a mock based solution.
-package unittest

--- a/tests/unit/info_test.go
+++ b/tests/unit/info_test.go
@@ -101,7 +101,8 @@ func (s *OshinkoUnitTestSuite) TestGetServiceAccountToken(c *check.C) {
 	observedToken, observedErr := info.GetServiceAccountToken()
 	c.Assert(observedToken, check.DeepEquals, expectedToken)
 	c.Assert(observedErr, check.Not(check.Equals), nil)
-	// TODO(elmiko) add a test that mocks out the file read for the token
+	// INFO(elmiko) this cannot be tested further given that a file read is
+	// required based on a const path set in the package.
 }
 
 func (s *OshinkoUnitTestSuite) TestGetServiceAccountNS(c *check.C) {
@@ -109,7 +110,8 @@ func (s *OshinkoUnitTestSuite) TestGetServiceAccountNS(c *check.C) {
 	observedNS, observedErr := info.GetServiceAccountNS()
 	c.Assert(observedNS, check.DeepEquals, expectedNS)
 	c.Assert(observedErr, check.Not(check.Equals), nil)
-	// TODO(elmiko) add a test that mocks out the file read for the namespace
+	// INFO(elmiko) this cannot be tested further given that a file read is
+	// required based on a const path set in the package.
 }
 
 func (s *OshinkoUnitTestSuite) TestGetWebServiceName(c *check.C) {

--- a/tests/unit/logging_test.go
+++ b/tests/unit/logging_test.go
@@ -1,4 +1,0 @@
-// INFO (elmiko)
-// Adding this file as a placeholder for the helpers/logging package,
-// this file will require a mock based solution.
-package unittest

--- a/tools/coverage.py
+++ b/tools/coverage.py
@@ -20,12 +20,10 @@ oshinko_repo = 'github.com/redhatanalytics/oshinko-rest/'
 oshinko_test_package = oshinko_repo + 'tests/unit'
 coverage_packages = [
     'handlers',
-    'helpers/authentication',
     'helpers/containers',
     'helpers/deploymentconfigs',
     'helpers/errors',
     'helpers/info',
-    'helpers/logging',
     'helpers/podtemplates',
     'helpers/services',
     'helpers/uuid',


### PR DESCRIPTION
The original intent of the empty tests was to leave room for mocked
tests. Unfortunately, it appears that the mocking route will not bear many
fruits and as such these files are being removed and the mock comments
changed in the info tests. Also removing the authentication and logging
helpers from the coverage script.
