### PR TITLE
add commit hash to version

### DIFF
--- a/restapi/configure_oshinko_rest.go
+++ b/restapi/configure_oshinko_rest.go
@@ -16,6 +16,7 @@ import (
 	"github.com/radanalyticsio/oshinko-rest/restapi/operations"
 	"github.com/radanalyticsio/oshinko-rest/restapi/operations/clusters"
 	"github.com/radanalyticsio/oshinko-rest/restapi/operations/server"
+	"github.com/radanalyticsio/oshinko-rest/version"
 )
 
 // This file is safe to edit. Once it exists it will not be overwritten
@@ -63,6 +64,8 @@ func configureAPI(api *operations.OshinkoRestAPI) http.Handler {
 	}
 
 	api.Logger = logging.GetLogger().Printf
+
+	logging.GetLogger().Println("Starting", version.GetAppName(), "version", version.GetVersion())
 
 	return setupGlobalMiddleware(api.Serve(setupMiddlewares))
 }

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -1,7 +1,9 @@
-TAG=`git describe --tags --abbrev=0 2> /dev/null | head -n1`
-if [ -z $TAG ]; then
-    TAG='0.0.0'
+GIT_TAG=`git describe --tags --abbrev=0 2> /dev/null | head -n1`
+if [ -z $GIT_TAG ]; then
+    GIT_TAG='unknown'
 fi
+GIT_COMMIT=`git log -n1 --pretty=format:%h`
+TAG="${GIT_TAG}-${GIT_COMMIT}"
 
 APP=oshinko-rest-server
 


### PR DESCRIPTION
This change will add the 7 digit commit hash to the tail of the tag name
when it is computed by the build tools. It also changes the default git
tag name to "unknown", this better reflects situations where the tags
have not be pulled from the source repo.

Changes
* update common script library tagname function to reflect commit hashes