### PR TITLE
Allow "default" to be specified as the named cluster config

### DIFF
--- a/helpers/clusterconfigs/clusterconfigs.go
+++ b/helpers/clusterconfigs/clusterconfigs.go
@@ -14,7 +14,7 @@ import (
 var defaultConfig models.NewClusterConfig = models.NewClusterConfig{1, "", 1}
 var configpath, globpath string
 
-const defaultname = "default"
+const Defaultname = "default"
 const failOnMissing = true
 const allowMissing = false
 const DefaultConfigPath = "/etc/oshinko-cluster-configs/"
@@ -117,8 +117,8 @@ func loadConfig(name string) (res models.NewClusterConfig, err error) {
 	// This can probably be smarter, assuming file timestamps
 	// work for ConfigMap volumes.
 	res = defaultConfig
-	err = readConfig(defaultname, &res, allowMissing)
-	if err == nil && name != "" && name != defaultname {
+	err = readConfig(Defaultname, &res, allowMissing)
+	if err == nil && name != "" && name != Defaultname {
 		err = readConfig(name, &res, failOnMissing)
 	}
 	return res, err

--- a/helpers/clusterconfigs/clusterconfigs.go
+++ b/helpers/clusterconfigs/clusterconfigs.go
@@ -118,7 +118,7 @@ func loadConfig(name string) (res models.NewClusterConfig, err error) {
 	// work for ConfigMap volumes.
 	res = defaultConfig
 	err = readConfig(defaultname, &res, allowMissing)
-	if err == nil && name != "" {
+	if err == nil && name != "" && name != defaultname {
 		err = readConfig(name, &res, failOnMissing)
 	}
 	return res, err

--- a/tests/unit/clusterconfigs_test.go
+++ b/tests/unit/clusterconfigs_test.go
@@ -17,6 +17,20 @@ func (s *OshinkoUnitTestSuite) TestGetConfigPath(c *check.C) {
 	c.Assert(newconfigpath, check.Equals, s.Configpath)
 }
 
+func (s *OshinkoUnitTestSuite) TestNoLocalDefault(c *check.C) {
+	// Test that if we ask for a named config "default" we do not
+	// get an error if there is no local override of default.
+	// For all other named configs, an error is returned if the local
+	// definition is not found.
+	DeleteDefaultConfig(s)
+	defconfig := clusterconfigs.GetDefaultConfig()
+	configarg := models.NewClusterConfig{Name: clusterconfigs.Defaultname}
+	myconfig, err := clusterconfigs.GetClusterConfig(&configarg)
+	c.Assert(err, check.IsNil)
+	c.Assert(myconfig.MasterCount, check.Equals, defconfig.MasterCount)
+	c.Assert(myconfig.WorkerCount, check.Equals, defconfig.WorkerCount)
+}
+
 func (s *OshinkoUnitTestSuite) TestDefaultConfig(c *check.C) {
 	// Test that with no config object passed in, we get the default config
 	defconfig := clusterconfigs.GetDefaultConfig()


### PR DESCRIPTION
If a user specifies "default" as the named config to use a cluster,
don't raise an error if there is not a local override of the
default config in the oshinko-cluster-configs config map. Specifying
default is unnecessary but valid.