### PR TITLE
Create an empty oshinko-spark-driver-config ConfigMap

### DIFF
--- a/tools/server-ui-template.yaml
+++ b/tools/server-ui-template.yaml
@@ -45,6 +45,11 @@ objects:
   data:
     small.workercount: "3"
 
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: oshinko-spark-driver-config
+
 - kind: DeploymentConfig
   apiVersion: v1
   metadata:


### PR DESCRIPTION
This empty ConfigMap will be mounted by default on
spark driver pods by the oshinko s2i templates. The presence
of an empty config directory will cause the start.sh
script to use the default spark configuration in the image.
If this ConfigMap is edited or a different one is used,
start.sh will use the config directory as the spark config.