### PR TITLE
add new-project failure logic to oshinko-deploy.sh

### DIFF
--- a/tools/oshinko-deploy.sh
+++ b/tools/oshinko-deploy.sh
@@ -136,7 +136,10 @@ fi
 
 oc login $OS_CLUSTER -u $OS_USER
 
-oc new-project $PROJECT
+if [[ `oc new-project $PROJECT` != 0 ]]
+then
+    oc project $PROJECT
+fi
 
 oc create sa oshinko -n $PROJECT
 oc policy add-role-to-user admin system:serviceaccount:$PROJECT:oshinko -n $PROJECT


### PR DESCRIPTION
This change adds logic to detect a failure of the `oc new-project`
command and then a clause to switch to the requested project on failure.