### PR TITLE
Create an empty config map to support spark driver config

### DIFF
--- a/tools/server-ui-template.yaml
+++ b/tools/server-ui-template.yaml
@@ -45,6 +45,11 @@ objects:
   data:
     small.workercount: "3"
 
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: oshinko-spark-driver-config
+
 - kind: DeploymentConfig
   apiVersion: v1
   metadata:


### PR DESCRIPTION
Since the config map volume is set up on the spark driver
from a template, and templates do not have conditional logic,
we need to create an empty configmap that can be used by
default when launching a dc or job from the templates
(locate in the s2i repo). If a user wants to change
the spark configuration, they can either modify the
default empty configmap, or create a new dc or job
which specifies an alternative configmap.