### PR TITLE
Remove the oshinko-spark-driver-config configmap

### DIFF
--- a/tools/server-ui-template.yaml
+++ b/tools/server-ui-template.yaml
@@ -38,11 +38,6 @@ objects:
     selector:
       name: ${OSHINKO_SERVER_NAME}
 
-- kind: ConfigMap
-  apiVersion: v1
-  metadata:
-    name: oshinko-spark-driver-config
-
 - kind: DeploymentConfig
   apiVersion: v1
   metadata:


### PR DESCRIPTION
This empty config map was a placeholder referenced from
s2i templates.  It is no longer needed.